### PR TITLE
Add types property to use generated declaration file rather than source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-interval-tree",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "files": [
     "lib/index.js",
     "lib/index.js.map",
-    "lib/index.d.ts"
+    "lib/index.d.ts",
+    "index.ts"
   ],
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.2",
   "description": "Implementation of interval tree data structure.",
   "main": "./lib/index.js",
-  "types": "./lib/main.d.ts",
+  "types": "./lib/index.d.ts",
   "engines": {
     "node": ">= 7.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "node-interval-tree",
   "version": "1.3.2",
   "description": "Implementation of interval tree data structure.",
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "types": "./lib/main.d.ts",
   "engines": {
     "node": ">= 7.6.0"
   },
@@ -36,8 +37,7 @@
   "files": [
     "lib/index.js",
     "lib/index.js.map",
-    "lib/index.d.ts",
-    "index.ts"
+    "lib/index.d.ts"
   ],
   "devDependencies": {
     "@types/chai": "^4.0.4",


### PR DESCRIPTION
Instead references the declaration file. This addresses an issue I've experienced which prevents me compiling my project as I have noImplicitReturns flag activated. (The problem function is in [remove Node](https://github.com/ShieldBattery/node-interval-tree/blob/master/index.ts#L386), but I can't actually see why there is an error (Error is Not all code paths return a value))