### PR TITLE
Readme: Update .insert() signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const intervalTree = new IntervalTree()
 
 ### Insert
 ```JavaScript
-intervalTree.insert(low, high, data)
+intervalTree.insert({ low, high, ...data })
 ```
 
 Insert an interval with associated data into the tree. Intervals with the same low and high value can be inserted, as long as their data is different.


### PR DESCRIPTION
This updates the `intervalTree.insert()` documentation to reflect the implementation, where it does not accept individual arguments for `low`, `high`, and `data` anymore.

This confused me for a moment, as the insert does not throw when given individual arguments, but the search then does not turn up any results.

Not sure if this is the best way to illustrate that it takes an `Interval` like object as an argument, let me know if I can / should improve on this.