### PR TITLE
Implement a reverse order iteration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -592,6 +592,10 @@ export class IntervalTree<T extends Interval<N>, N extends number | bigint = num
     return new InOrder(this.root)
   }
 
+  public reverseInOrder() {
+    return new ReverseInOrder(this.root)
+  }
+
   public preOrder() {
     return new PreOrder(this.root)
   }
@@ -692,6 +696,68 @@ export class InOrder<T extends Interval<N>, N extends number | bigint = number>
   private pop() {
     this.currentNode = this.stack.pop()
     this.i = 0
+  }
+}
+
+export class ReverseInOrder<T extends Interval<N>, N extends number | bigint = number>
+  implements IterableIterator<T>
+{
+  private stack: Node<T, N>[] = []
+
+  private currentNode?: Node<T, N>
+  private i: number
+
+  constructor(startNode?: Node<T, N>) {
+    if (startNode !== undefined) {
+      this.push(startNode)
+    }
+  }
+
+  [Symbol.iterator]() {
+    return this
+  }
+
+  public next(): IteratorResult<T> {
+    // Will only happen if stack is empty and pop is called
+    if (this.currentNode === undefined) {
+      return {
+        done: true,
+        value: undefined,
+      } as any as IteratorResult<T>
+    }
+
+    // Process this node
+    if (this.currentNode.records.length && this.i >= 0) {
+      return {
+        done: false,
+        value: this.currentNode.records[this.i--],
+      }
+    }
+
+    if (this.currentNode.left !== undefined) {
+      // Can we go left?
+      this.push(this.currentNode.left)
+    } else {
+      // Otherwise go up
+      // Might pop the last and set this.currentNode = undefined
+      this.pop()
+    }
+    return this.next()
+  }
+
+  private push(node: Node<T, N>) {
+    this.currentNode = node
+    this.i = 0
+
+    while (this.currentNode.right !== undefined) {
+      this.stack.push(this.currentNode)
+      this.currentNode = this.currentNode.right
+    }
+  }
+
+  private pop() {
+    this.currentNode = this.stack.pop()
+    this.i = (this.currentNode?.records.length ?? 0) - 1
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -627,6 +627,10 @@ export default class DataIntervalTree<T, N extends number | bigint = number> {
   public inOrder() {
     return this.tree.inOrder()
   }
+  
+  public reverseInOrder() {
+    return this.tree.reverseInOrder()
+  }
 
   public preOrder() {
     return this.tree.preOrder()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-interval-tree",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-interval-tree",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "shallowequal": "^1.1.0"

--- a/test/test.ts
+++ b/test/test.ts
@@ -265,6 +265,28 @@ describe('Interval tree', () => {
     })
   })
 
+  describe('ReverseInOrder', () => {
+    it('should traverse in reverse order', () => {
+      const tree = new IntervalTree<StringInterval>()
+
+      const values: [number, number, string][] = [
+        [50, 150, 'data1'],
+        [75, 100, 'data2'],
+        [40, 100, 'data3'],
+        [60, 150, 'data4'],
+        [80, 90, 'data5'],
+        [85, 88, 'data6'],
+        [88, 89, 'data7'],
+      ]
+
+      values.map(([low, high, value]) => ({ low, high, data: value })).forEach(i => tree.insert(i))
+
+      const order = ['data7', 'data6', 'data5', 'data2', 'data4', 'data1', 'data3']
+      const data = iteratorToArray(tree.reverseInOrder()).map(v => v.data)
+      expect(data).to.eql(order)
+    })
+  })
+
   describe('PreOrder', () => {
     it('should traverse pre order', () => {
       const tree = new IntervalTree<StringInterval>()


### PR DESCRIPTION
Just rounding out the iterator to include a reverse order as this is often included in tree traversals.

Just iterates through the right of the tree first, and over the records of each node in reverse order